### PR TITLE
Add Fusl to sponsors.

### DIFF
--- a/contents/about.yml
+++ b/contents/about.yml
@@ -42,3 +42,7 @@
   sponsor: GlobalSign
   homepage: https://www.globalsign.com/en/
   gratitude: SSL certificates for our community sites.
+-
+  sponsor: Fusl
+  homepage: http://fuslvz.ws/fuslvz.html
+  gratitude: Virtual machine for our e-mail server.


### PR DESCRIPTION
This sponsor's [FuslVZ](fuslvz.ws/fuslvz.html) initiative provided us a server in Ukraine that would serve as backup MX and spam filtering. Adding her name to the sponsors list to express gratitude.