### PR TITLE
mirrors-status: Add option for testing

### DIFF
--- a/static/assets/js/mirror-status.js
+++ b/static/assets/js/mirror-status.js
@@ -69,6 +69,9 @@ function genList() {
   for (var i = 0; i < final_result.length; i++) {
     var prefix = (i ? '# ' : '');
     output += '# ' + final_result[i].name + '\n#\n' + prefix + 'deb ' + final_result[i].url + 'os-' + cpu_arch + '/os3-dpkg /\n' + prefix + 'deb ' + final_result[i].url + 'os-noarch/os3-dpkg /\n#\n';
+    if ($('#testing-chkbox').is(":checked")) {
+      output += 'deb ' + final_result[i].url + 'os-' + cpu_arch + '/testing/os-' + cpu_arch + '/os3-dpkg /\n' + prefix + 'deb ' + final_result[i].url + 'os-noarch/testing/os-noarch/os3-dpkg /\n#\n';
+    }
   }
   download('sources.list', output);
 }

--- a/views/mirror-status.pug
+++ b/views/mirror-status.pug
@@ -81,6 +81,9 @@ block content
       for mirror in params.mirrors
         +mirror-entry(mirror, params.repo_info)
   p
+    div.checkbox(style="float: right")
+      input#testing-chkbox(type="checkbox")
+      label(for="testing-chkbox") Enable testing?
     a.btn.btn-primary#gen-btn(href="javascript:void(0);", onclick="startMeasurement();") Generate APT Configuration
     span(style="display: none;")#pdesc Crunching mirrors information for you, just a moment...!
     div.progress(style="display: none;")#pbar


### PR DESCRIPTION
It's ugly but it can work :)

~~BTW, I use `$('input[type=checkbox]')` instead of  `$('testing-chkbox').is(":checked")` is simply because it cannot work, and I don't know what the heck is wrong with it 🤦‍♀️.~~ (My mistake)